### PR TITLE
Update age references

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Método de verificación utilizado por Barcelona En Comú. Una vez el usuario se
 inscribe digitalmente debe ir a verificarse presencialmente. Por otro lado un
 grupo de usuarios de confianza para la organización se encarga de verificar
 presencialmente los documentos con los requisitos mínimos que debe cumplir (ser
-mayor de 16 años y con domicilio en Barcelona).
+mayor de 18 años y con domicilio en Barcelona).
 
 * https://barcelonaencomu.cat/es/post/inscribete-bcomu-hagamos-juntos-otra-barcelona
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,9 +3,6 @@ class User < ActiveRecord::Base
 
   validates :inscription, acceptance: '1'
 
-  validates :born_at, inclusion: { in: Date.civil(1900, 1, 1)..Date.today-16.years,
-    message: "debes ser mayor de 16 años" }, allow_blank: true
-
   before_validation :set_location
 
   def set_location

--- a/vendor/overrides/encomu/config/locales/app.ca.yml
+++ b/vendor/overrides/encomu/config/locales/app.ca.yml
@@ -112,7 +112,7 @@ ca:
         wants_newsletter: 'Butlletí'
         terms_of_service: "He llegit i accepto les condicions generals"
         inscription: "Accepto incriure'm a Barcelona en Comú"
-        over_18: "Declaro ser major de 16 anys"
+        over_18: "Declaro ser major de 18 anys"
         captcha: "Captcha"
         current_password: "Contrasenya actual"
   formtastic:
@@ -529,7 +529,7 @@ Amb tres passos molt senzills:
       <li>
       <a class='cd-faq-trigger' href='#0'>10. Qui pot votar?</a>
       <div class='cd-faq-content'>
-        <p>Qualsevol  persona inscrita a Barcelona En Comú a través de  http://participa.barcelonaencomu.cat que tingui més de 16 anys i visqui a  Barcelona i hagi realitzat la verificació presencial.</p>
+        <p>Qualsevol  persona inscrita a Barcelona En Comú a través de  http://participa.barcelonaencomu.cat que tingui més de 18 anys i visqui a  Barcelona i hagi realitzat la verificació presencial.</p>
       </div> <!-- cd-faq-content -->
       </li>
       <li>
@@ -714,6 +714,6 @@ Amb tres passos molt senzills:
         message: "Has sigut verificat i ja formes part de la comunitat de Barcelona en Comú. A partir d'ara ja no necessites verificar-te més i podràs participar a les consultes futures. Cada cop que hi hagi una consulta t'avisarem per coreru electrònic perquè puguis participar. Recorda que ara formes part de la comunitat de Barcelona en Comú."
     form:
       document: "He verificat el document original de l'inscrit/a"
-      age: "L'inscrit/a és major de 16 anys - nascut abans de %{date}"
+      age: "L'inscrit/a és major de 18 anys - nascut abans de %{date}"
       town: "He verificat un document (DNI/NIE/Passaport, rebut d'un subministrament) que acredita que l'inscrit/a viu a Barcelona."
 

--- a/vendor/overrides/encomu/config/locales/app.es.yml
+++ b/vendor/overrides/encomu/config/locales/app.es.yml
@@ -131,7 +131,7 @@ es:
         wants_newsletter: 'Newsletter'
         terms_of_service: "He leído y acepto la Política de Privacidad, Aviso Legal y Política de Cookies"
         inscription: "Acepto incribirme en la candidatura"
-        over_18: "Declaro ser mayor de 16 años"
+        over_18: "Declaro ser mayor de 18 años"
         captcha: "Escribe el siguiente texto o número"
         current_password: "Contraseña actual"
 
@@ -568,7 +568,7 @@ Barcelona en Comú cumple con todas las medidas de seguridad para la protección
           <li>
           <a class="cd-faq-trigger" href="#0">10. ¿Quién puede votar?</a>
           <div class="cd-faq-content">
-            <p>Cualquier persona que haya realizado la inscripción en <a href="https://participa.barcelonaencomu.cat" target="_blank">participa.barcelonaencomu.cat</a>, y se haya verificado presencialmente aportando los documentos que se solicitan y tenga más de 16 años.</p>
+            <p>Cualquier persona que haya realizado la inscripción en <a href="https://participa.barcelonaencomu.cat" target="_blank">participa.barcelonaencomu.cat</a>, y se haya verificado presencialmente aportando los documentos que se solicitan y tenga más de 18 años.</p>
           </div> <!-- cd-faq-content -->
           </li>
           <li>
@@ -713,7 +713,7 @@ Barcelona en Comú cumple con todas las medidas de seguridad para la protección
     step1: Pedir documentos
     step2: Pedir correo electrónico
     step3: Comprobar
-    welcome_html: "<p>Pídele amablemente al usuario/a los documentos que debe haber traído y comprueba que sea <b>mayor de 16 años y que la dirección sea de Barcelona</b>. En caso de que el DNI o NIE no tenga dirección en Barcelona, o en le caso de pasaporte y carnet de conducir, que no pone dirección, se deberá aportar: <ul>
+    welcome_html: "<p>Pídele amablemente al usuario/a los documentos que debe haber traído y comprueba que sea <b>mayor de 18 años y que la dirección sea de Barcelona</b>. En caso de que el DNI o NIE no tenga dirección en Barcelona, o en le caso de pasaporte y carnet de conducir, que no pone dirección, se deberá aportar: <ul>
       <li>
    -Algún documento que acredite dirección en Barcelona:
      </li>
@@ -781,7 +781,7 @@ Gracias por inscribirte en Barcelona en Comú."
 <p>Gracias por inscribirte en Barcelona en Comú.</p>"
     form:
       document: He verificado el documento original del inscrito/a
-      age: El inscrito/a es mayor de 16 años - nacido/a antes de %{date}
+      age: El inscrito/a es mayor de 18 años - nacido/a antes de %{date}
       town: He verificado un documento (DNI/NIE/Pasaporte, recibo de un suministro) que acredita que el inscrito/a vive en Barcelona
   podemos:
     error:


### PR DESCRIPTION
Implements https://proyectos.alabs.org/issues/1023.

Just going back to the original "18 years old" age restriction.