### PR TITLE
Revert "Update age references"

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Método de verificación utilizado por Barcelona En Comú. Una vez el usuario se
 inscribe digitalmente debe ir a verificarse presencialmente. Por otro lado un
 grupo de usuarios de confianza para la organización se encarga de verificar
 presencialmente los documentos con los requisitos mínimos que debe cumplir (ser
-mayor de 18 años y con domicilio en Barcelona).
+mayor de 16 años y con domicilio en Barcelona).
 
 * https://barcelonaencomu.cat/es/post/inscribete-bcomu-hagamos-juntos-otra-barcelona
 

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -151,7 +151,7 @@ class RegistrationsController < Devise::RegistrationsController
         document_type
         document_vatid
         terms_of_service
-        over_18
+        age_restriction
         inscription
         vote_town
         vote_province

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,7 +57,7 @@ class User < ActiveRecord::Base
   validates :email, confirmation: true, on: :create, :email => true
   validates :email_confirmation, presence: true, on: :create
   validates :terms_of_service, acceptance: true
-  validates :over_18, acceptance: true
+  validates :age_restriction, acceptance: true
   validates :document_type, inclusion: { in: [1, 2, 3], message: "Tipo de documento no válido" }
   validates :document_vatid, valid_nif: true, if: :is_document_dni?
   validates :document_vatid, valid_nie: true, if: :is_document_nie?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,9 +3,6 @@ class User < ActiveRecord::Base
 
   validates :inscription, acceptance: '1'
 
-  validates :born_at, inclusion: { in: Date.civil(1900, 1, 1)..Date.today-16.years,
-    message: "debes ser mayor de 16 años" }, allow_blank: true
-
   before_validation :set_location
 
   def set_location
@@ -62,8 +59,8 @@ class User < ActiveRecord::Base
   validates :document_vatid, valid_nif: true, if: :is_document_dni?
   validates :document_vatid, valid_nie: true, if: :is_document_nie?
   validates :born_at, date: true, allow_blank: true # gem date_validator
-  validates :born_at, inclusion: { in: Date.civil(1900, 1, 1)..Date.today-18.years,
-    message: "debes ser mayor de 18 años" }, allow_blank: true
+  validates :born_at, inclusion: { in: Date.civil(1900, 1, 1)..Date.today-16.years,
+    message: "debes ser mayor de 16 años" }, allow_blank: true
   validates :phone, numericality: true, allow_blank: true
   validates :unconfirmed_phone, numericality: true, allow_blank: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,9 @@ class User < ActiveRecord::Base
 
   validates :inscription, acceptance: '1'
 
+  validates :born_at, inclusion: { in: Date.civil(1900, 1, 1)..Date.today-16.years,
+    message: "debes ser mayor de 16 años" }, allow_blank: true
+
   before_validation :set_location
 
   def set_location

--- a/app/views/devise/registrations/_form.html.erb
+++ b/app/views/devise/registrations/_form.html.erb
@@ -185,12 +185,12 @@
         </div>
 
         <div class="inputlabel-box">
-          <% if resource.errors.include?(:over_18) %>
+          <% if resource.errors.include?(:age_restriction) %>
               <%= field_notice_box %>
           <% end %>
-          <%= f.label :over_18 %>
+          <%= f.label :age_restriction %>
           <div class="input-box">
-            <%= f.check_box :over_18, class: 'checkbox' %>
+            <%= f.check_box :age_restriction, class: 'checkbox' %>
             <p class="text-xl">Declaro ser mayor de 18 años</p>
           </div>
         </div>

--- a/app/views/verification/step1.html.erb
+++ b/app/views/verification/step1.html.erb
@@ -28,8 +28,8 @@
           </div>
 
           <div class="inputlabel-box">
-            <input class="checkbox" id="user_over_18" name="user[over_18]" value="1" required="true" type="checkbox">
-            <label for="user_over_18">
+            <input class="checkbox" id="user_age_restriction" name="user[age_restriction]" value="1" required="true" type="checkbox">
+            <label for="user_age_restriction">
               <%= t('verification.form.age', date: l( Date.today - 16.years ) ) %>
             </label>
           </div>

--- a/config/locales/app.es.yml
+++ b/config/locales/app.es.yml
@@ -306,7 +306,7 @@ es:
         remember_me: "Recordarme"
         wants_newsletter: 'Newsletter'
         terms_of_service: "He leído y acepto las condiciones generales"
-        over_18: "Declaro ser mayor de 18 años"
+        age_restriction: "Declaro ser mayor de 18 años"
         captcha: "Captcha"
         current_password: "Contraseña actual"
         circle: "Círculo"

--- a/test/features/concerns/registration_helpers.rb
+++ b/test/features/concerns/registration_helpers.rb
@@ -36,7 +36,7 @@ module Participa
         check('user_terms_of_service')
         # XXX: the cookie policy gets in the middle here, so check won't work.
         # Investigate and fix
-        find('input[type=checkbox]#user_over_18').trigger('click')
+        find('input[type=checkbox]#user_age_restriction').trigger('click')
       end
 
       def fill_in_login_data(user, email)

--- a/test/features/verification_presencial_test.rb
+++ b/test/features/verification_presencial_test.rb
@@ -51,7 +51,7 @@ feature "VerificationPresencial" do
     page.must_have_content I18n.t('verification.form.document')
     check('user_document')
     check('user_town')
-    check('user_over_18')
+    check('user_age_restriction')
     click_button('Siguiente')
     fill_in(:user_email, with: user2.email)
     click_button('Siguiente')

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -123,14 +123,14 @@ class UserTest < ActiveSupport::TestCase
     u.errors[:age_restriction].include? ["debe ser aceptado"]
   end
 
-  test "should have valid born_at" do
-    u = User.new(born_at: Date.civil(2017, 2, 1))
+  test "should be over 16 years old" do
+    u = User.new(born_at: Date.today - (16.years - 1.day))
     u.valid?
     assert(u.errors[:born_at].include? "debes ser mayor de 16 años")
     u = User.new(born_at: Date.civil(1888, 2, 1))
     u.valid?
     assert(u.errors[:born_at].include? "debes ser mayor de 16 años")
-    u = User.new(born_at: Date.civil(1988, 2, 1))
+    u = User.new(born_at: Date.today - (16.years + 1.day))
     u.valid?
     assert(u.errors[:born_at], [])
   end
@@ -402,13 +402,6 @@ class UserTest < ActiveSupport::TestCase
     assert_not user.valid?
     assert user.errors[:email_confirmation].include? "no coincide con la confirmación"
   end
-
-  test "should be over 16 on born_at" do 
-    user = FactoryGirl.build(:user, born_at: Date.civil(2002, 1, 1))
-    user.valid?
-    assert_not user.valid?
-    assert user.errors[:born_at].include? "debes ser mayor de 16 años"
-  end 
 
   test "should province_name work with all kind of profile data" do
     user = FactoryGirl.create(:user)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -116,20 +116,20 @@ class UserTest < ActiveSupport::TestCase
     assert(user5.valid?)
   end
 
-  test "should accept terms of service and over_18" do
-    u = User.new(terms_of_service: false, over_18: false)
+  test "should accept terms of service and age_restriction" do
+    u = User.new(terms_of_service: false, age_restriction: false)
     u.valid?
     u.errors[:terms_of_service].include? ["debe ser aceptado"]
-    u.errors[:over_18].include? ["debe ser aceptado"]
+    u.errors[:age_restriction].include? ["debe ser aceptado"]
   end
 
   test "should have valid born_at" do
     u = User.new(born_at: Date.civil(2017, 2, 1))
     u.valid?
-    assert(u.errors[:born_at].include? "debes ser mayor de 18 años")
+    assert(u.errors[:born_at].include? "debes ser mayor de 16 años")
     u = User.new(born_at: Date.civil(1888, 2, 1))
     u.valid?
-    assert(u.errors[:born_at].include? "debes ser mayor de 18 años")
+    assert(u.errors[:born_at].include? "debes ser mayor de 16 años")
     u = User.new(born_at: Date.civil(1988, 2, 1))
     u.valid?
     assert(u.errors[:born_at], [])
@@ -403,11 +403,11 @@ class UserTest < ActiveSupport::TestCase
     assert user.errors[:email_confirmation].include? "no coincide con la confirmación"
   end
 
-  test "should be over 18 on born_at" do 
-    user = FactoryGirl.build(:user, born_at: Date.civil(2000, 1, 1))
+  test "should be over 16 on born_at" do 
+    user = FactoryGirl.build(:user, born_at: Date.civil(2002, 1, 1))
     user.valid?
     assert_not user.valid?
-    assert user.errors[:born_at].include? "debes ser mayor de 18 años"
+    assert user.errors[:born_at].include? "debes ser mayor de 16 años"
   end 
 
   test "should province_name work with all kind of profile data" do

--- a/vendor/overrides/encomu/app/views/devise/registrations/_form.html.erb
+++ b/vendor/overrides/encomu/app/views/devise/registrations/_form.html.erb
@@ -249,12 +249,12 @@
         </div>
 
         <div class="inputlabel-box">
-          <% if resource.errors.include?(:over_18) %>
+          <% if resource.errors.include?(:age_restriction) %>
               <%= field_notice_box %>
           <% end %>
-          <%= f.label :over_18 %>
+          <%= f.label :age_restriction %>
           <div class="input-box">
-            <%= f.check_box :over_18, class: 'checkbox' %>
+            <%= f.check_box :age_restriction, class: 'checkbox' %>
           </div>
         </div>
 

--- a/vendor/overrides/encomu/config/locales/app.ca.yml
+++ b/vendor/overrides/encomu/config/locales/app.ca.yml
@@ -121,7 +121,7 @@ ca:
         wants_newsletter: 'Butlletí'
         terms_of_service: "He llegit i accepto les condicions generals"
         inscription: "Accepto incriure'm a Barcelona en Comú"
-        over_18: "Declaro ser major de 18 anys"
+        over_18: "Declaro ser major de 16 anys"
         captcha: "Captcha"
         current_password: "Contrasenya actual"
   formtastic:
@@ -544,7 +544,7 @@ Amb tres passos molt senzills:
       <li>
       <a class='cd-faq-trigger' href='#0'>10. Qui pot votar?</a>
       <div class='cd-faq-content'>
-        <p>Qualsevol  persona inscrita a Barcelona En Comú a través de  http://participa.barcelonaencomu.cat que tingui més de 18 anys i visqui a  Barcelona i hagi realitzat la verificació presencial.</p>
+        <p>Qualsevol  persona inscrita a Barcelona En Comú a través de  http://participa.barcelonaencomu.cat que tingui més de 16 anys i visqui a  Barcelona i hagi realitzat la verificació presencial.</p>
       </div> <!-- cd-faq-content -->
       </li>
       <li>
@@ -729,6 +729,6 @@ Amb tres passos molt senzills:
         message: "Has sigut verificat i ja formes part de la comunitat de Barcelona en Comú. A partir d'ara ja no necessites verificar-te més i podràs participar a les consultes futures. Cada cop que hi hagi una consulta t'avisarem per coreru electrònic perquè puguis participar. Recorda que ara formes part de la comunitat de Barcelona en Comú."
     form:
       document: "He verificat el document original de l'inscrit/a"
-      age: "L'inscrit/a és major de 18 anys - nascut abans de %{date}"
+      age: "L'inscrit/a és major de 16 anys - nascut abans de %{date}"
       town: "He verificat un document (DNI/NIE/Passaport, rebut d'un subministrament) que acredita que l'inscrit/a viu a Barcelona."
 

--- a/vendor/overrides/encomu/config/locales/app.ca.yml
+++ b/vendor/overrides/encomu/config/locales/app.ca.yml
@@ -121,7 +121,7 @@ ca:
         wants_newsletter: 'Butlletí'
         terms_of_service: "He llegit i accepto les condicions generals"
         inscription: "Accepto incriure'm a Barcelona en Comú"
-        over_18: "Declaro ser major de 16 anys"
+        age_restriction: "Declaro ser major de 16 anys"
         captcha: "Captcha"
         current_password: "Contrasenya actual"
   formtastic:

--- a/vendor/overrides/encomu/config/locales/app.es.yml
+++ b/vendor/overrides/encomu/config/locales/app.es.yml
@@ -140,7 +140,7 @@ es:
         wants_newsletter: 'Newsletter'
         terms_of_service: "He leído y acepto la Política de Privacidad, Aviso Legal y Política de Cookies"
         inscription: "Acepto incribirme en la candidatura"
-        over_18: "Declaro ser mayor de 18 años"
+        over_18: "Declaro ser mayor de 16 años"
         captcha: "Escribe el siguiente texto o número"
         current_password: "Contraseña actual"
 
@@ -583,7 +583,7 @@ Barcelona en Comú cumple con todas las medidas de seguridad para la protección
           <li>
           <a class="cd-faq-trigger" href="#0">10. ¿Quién puede votar?</a>
           <div class="cd-faq-content">
-            <p>Cualquier persona que haya realizado la inscripción en <a href="https://participa.barcelonaencomu.cat" target="_blank">participa.barcelonaencomu.cat</a>, y se haya verificado presencialmente aportando los documentos que se solicitan y tenga más de 18 años.</p>
+            <p>Cualquier persona que haya realizado la inscripción en <a href="https://participa.barcelonaencomu.cat" target="_blank">participa.barcelonaencomu.cat</a>, y se haya verificado presencialmente aportando los documentos que se solicitan y tenga más de 16 años.</p>
           </div> <!-- cd-faq-content -->
           </li>
           <li>
@@ -728,7 +728,7 @@ Barcelona en Comú cumple con todas las medidas de seguridad para la protección
     step1: Pedir documentos
     step2: Pedir correo electrónico
     step3: Comprobar
-    welcome_html: "<p>Pídele amablemente al usuario/a los documentos que debe haber traído y comprueba que sea <b>mayor de 18 años y que la dirección sea de Barcelona</b>. En caso de que el DNI o NIE no tenga dirección en Barcelona, o en le caso de pasaporte y carnet de conducir, que no pone dirección, se deberá aportar: <ul>
+    welcome_html: "<p>Pídele amablemente al usuario/a los documentos que debe haber traído y comprueba que sea <b>mayor de 16 años y que la dirección sea de Barcelona</b>. En caso de que el DNI o NIE no tenga dirección en Barcelona, o en le caso de pasaporte y carnet de conducir, que no pone dirección, se deberá aportar: <ul>
       <li>
    -Algún documento que acredite dirección en Barcelona:
      </li>
@@ -796,7 +796,7 @@ Gracias por inscribirte en Barcelona en Comú."
 <p>Gracias por inscribirte en Barcelona en Comú.</p>"
     form:
       document: He verificado el documento original del inscrito/a
-      age: El inscrito/a es mayor de 18 años - nacido/a antes de %{date}
+      age: El inscrito/a es mayor de 16 años - nacido/a antes de %{date}
       town: He verificado un documento (DNI/NIE/Pasaporte, recibo de un suministro) que acredita que el inscrito/a vive en Barcelona
   podemos:
     error:

--- a/vendor/overrides/encomu/config/locales/app.es.yml
+++ b/vendor/overrides/encomu/config/locales/app.es.yml
@@ -140,7 +140,7 @@ es:
         wants_newsletter: 'Newsletter'
         terms_of_service: "He leído y acepto la Política de Privacidad, Aviso Legal y Política de Cookies"
         inscription: "Acepto incribirme en la candidatura"
-        over_18: "Declaro ser mayor de 16 años"
+        age_restriction: "Declaro ser mayor de 16 años"
         captcha: "Escribe el siguiente texto o número"
         current_password: "Contraseña actual"
 


### PR DESCRIPTION
Reverts EnComu/participa#9

We should allow registrations from 16 years instead of 18. 