### PR TITLE
Improve captcha experience

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'sprockets-rails', '2.3.3' # http://stackoverflow.com/a/34344602
 
 gem 'pg'
 gem 'rb-readline'
-gem 'airbrake'
+gem 'airbrake', group: :production
 
 gem 'devise'
 gem 'cancancan', '~> 1.9'

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -69,15 +69,13 @@ class RegistrationsController < Devise::RegistrationsController
     build_resource(sign_up_params)
     if resource.is_captcha_valid?
       super do
-        status = user_already_exists? :document_vatid
-        if status and resource.errors.empty?
+        if valid_with_dup?(:document_vatid)
           UsersMailer.remember_email(:document_vatid, resource.document_vatid).deliver_now
           redirect_to(root_path, notice: t("devise.registrations.signed_up_but_unconfirmed"))
           return
         end
 
-        status = user_already_exists? :email
-        if status and resource.errors.empty?
+        if valid_with_dup?(:email)
           UsersMailer.remember_email(:email, resource.email).deliver_now
           redirect_to(root_path, notice: t("devise.registrations.signed_up_but_unconfirmed"))
           return
@@ -105,6 +103,12 @@ class RegistrationsController < Devise::RegistrationsController
   end
 
   private
+
+  def valid_with_dup?(type)
+    return false unless user_already_exists?(type)
+
+    resource.errors.empty?
+  end
 
   def user_already_exists?(type)
     # FIX for https://github.com/plataformatec/devise/issues/3540

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -69,16 +69,16 @@ class RegistrationsController < Devise::RegistrationsController
     build_resource(sign_up_params)
     if resource.is_captcha_valid?
       super do
-        result, status = user_already_exists? resource, :document_vatid
-        if status and result.errors.empty?
-          UsersMailer.remember_email(:document_vatid, result.document_vatid).deliver_now
+        status = user_already_exists? :document_vatid
+        if status and resource.errors.empty?
+          UsersMailer.remember_email(:document_vatid, resource.document_vatid).deliver_now
           redirect_to(root_path, notice: t("devise.registrations.signed_up_but_unconfirmed"))
           return
         end
 
-        result, status = user_already_exists? resource, :email
-        if status and result.errors.empty?
-          UsersMailer.remember_email(:email, result.email).deliver_now
+        status = user_already_exists? :email
+        if status and resource.errors.empty?
+          UsersMailer.remember_email(:email, resource.email).deliver_now
           redirect_to(root_path, notice: t("devise.registrations.signed_up_but_unconfirmed"))
           return
         end
@@ -106,7 +106,7 @@ class RegistrationsController < Devise::RegistrationsController
 
   private
 
-  def user_already_exists?(resource, type)
+  def user_already_exists?(type)
     # FIX for https://github.com/plataformatec/devise/issues/3540
     # Devise paranoid only works for passwords resets.
     # With the uniqueness validation on user.document_vatid and user.email
@@ -122,9 +122,9 @@ class RegistrationsController < Devise::RegistrationsController
     if resource.errors.added? type, :taken
       resource.errors.messages[type] -= [ t('activerecord.errors.models.user.attributes.' + type.to_s + '.taken') ]
       resource.errors.delete(type) if resource.errors.messages[type].empty?
-      return resource, true
+      return true
     else
-      return resource, false
+      return false
     end
   end
 

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -67,14 +67,8 @@ class RegistrationsController < Devise::RegistrationsController
 
   def create
     build_resource(sign_up_params)
-    if resource.is_captcha_valid?
+    if resource.valid_with_captcha?
       super do
-        redirect_if_valid_dup(:document_vatid)
-        return if performed?
-
-        redirect_if_valid_dup(:email)
-        return if performed?
-
         # If the user already had a location but deleted itslet, he should have
         # his previous location
         #
@@ -83,6 +77,12 @@ class RegistrationsController < Devise::RegistrationsController
         end
       end
     else
+      redirect_if_valid_dup(:document_vatid)
+      return if performed?
+
+      redirect_if_valid_dup(:email)
+      return if performed?
+
       clean_up_passwords(resource)
       render :new
     end

--- a/config/initializers/errbit.rb
+++ b/config/initializers/errbit.rb
@@ -1,11 +1,13 @@
-Airbrake.configure do |config|
-  airbrake_secrets = Rails.application.secrets.airbrake
+if Rails.env.production?
+  Airbrake.configure do |config|
+    airbrake_secrets = Rails.application.secrets.airbrake
 
-  protocol = "http#{airbrake_secrets['port'].to_i == 443 ? 's' : ''}"
-  host = airbrake_secrets['host']
-  port = airbrake_secrets['port']
+    protocol = "http#{airbrake_secrets['port'].to_i == 443 ? 's' : ''}"
+    host = airbrake_secrets['host']
+    port = airbrake_secrets['port']
 
-  config.project_key = airbrake_secrets["api_key"]
-  config.host = "#{protocol}://#{host}:#{port}"
-  config.project_id = 1
+    config.project_key = airbrake_secrets["api_key"]
+    config.host = "#{protocol}://#{host}:#{port}"
+    config.project_id = 1
+  end
 end

--- a/test/features/concerns/registration_helpers.rb
+++ b/test/features/concerns/registration_helpers.rb
@@ -41,8 +41,20 @@ module Participa
       end
 
       def acknowledge_stuff
+        acknowledge_inscription
+        acknowledge_terms
+        acknowledge_age
+      end
+
+      def acknowledge_inscription
         check('user_inscription')
+      end
+
+      def acknowledge_terms
         check('user_terms_of_service')
+      end
+
+      def acknowledge_age
         # XXX: the cookie policy gets in the middle here, so check won't work.
         # Investigate and fix
         find('input[type=checkbox]#user_age_restriction').trigger('click')

--- a/test/features/concerns/registration_helpers.rb
+++ b/test/features/concerns/registration_helpers.rb
@@ -1,6 +1,15 @@
 module Participa
   module Test
     module RegistrationHelpers
+      def with_captcha_enabled
+        old_always_pass = SimpleCaptcha.always_pass
+        SimpleCaptcha.always_pass = false
+
+        yield
+      ensure
+        SimpleCaptcha.always_pass = old_always_pass
+      end
+
       def create_user_registration(user, document_vatid, email)
         visit new_user_registration_path
         fill_in_user_registration(user, document_vatid, email)

--- a/test/features/concerns/registration_helpers.rb
+++ b/test/features/concerns/registration_helpers.rb
@@ -1,13 +1,19 @@
 module Participa
   module Test
     module RegistrationHelpers
-      def with_captcha_enabled
-        old_always_pass = SimpleCaptcha.always_pass
+      def setup
+        @old_always_pass = SimpleCaptcha.always_pass
         SimpleCaptcha.always_pass = false
 
-        yield
-      ensure
-        SimpleCaptcha.always_pass = old_always_pass
+        @user = FactoryGirl.build(:user)
+
+        super
+      end
+
+      def teardown
+        super
+
+        SimpleCaptcha.always_pass = @old_always_pass
       end
 
       def create_user_registration(user, document_vatid, email)
@@ -44,6 +50,7 @@ module Participa
         acknowledge_inscription
         acknowledge_terms
         acknowledge_age
+        fill_in_captcha
       end
 
       def acknowledge_inscription
@@ -58,6 +65,10 @@ module Participa
         # XXX: the cookie policy gets in the middle here, so check won't work.
         # Investigate and fix
         find('input[type=checkbox]#user_age_restriction').trigger('click')
+      end
+
+      def fill_in_captcha
+        fill_in 'user[captcha]', with: SimpleCaptcha::SimpleCaptchaData.first.value
       end
 
       def fill_in_login_data(user, email)

--- a/test/features/user_registrations_test.rb
+++ b/test/features/user_registrations_test.rb
@@ -50,20 +50,22 @@ feature "UserRegistrations" do
   end
 
   scenario "captcha succeeds", js: true do
-    SimpleCaptcha.always_pass = false
-    visit new_user_registration_path
-    fill_in_user_registration(@user, @user.document_vatid, @user.email)
-    fill_in 'user[captcha]', with: SimpleCaptcha::SimpleCaptchaData.first.value
-    click_button 'Inscribirse'
-    assert_no_text 'El texto introducido no corresponde con el de la imagen'
+    with_captcha_enabled do
+      visit new_user_registration_path
+      fill_in_user_registration(@user, @user.document_vatid, @user.email)
+      fill_in 'user[captcha]', with: SimpleCaptcha::SimpleCaptchaData.first.value
+      click_button 'Inscribirse'
+      assert_no_text 'El texto introducido no corresponde con el de la imagen'
+    end
   end
 
   scenario "captcha fails", js: true do
-    SimpleCaptcha.always_pass = false
-    visit new_user_registration_path
-    fill_in_user_registration(@user, @user.document_vatid, @user.email)
-    click_button 'Inscribirse'
-    assert_text 'El texto introducido no corresponde con el de la imagen'
+    with_captcha_enabled do
+      visit new_user_registration_path
+      fill_in_user_registration(@user, @user.document_vatid, @user.email)
+      click_button 'Inscribirse'
+      assert_text 'El texto introducido no corresponde con el de la imagen'
+    end
   end
 
   private

--- a/test/features/user_registrations_test.rb
+++ b/test/features/user_registrations_test.rb
@@ -61,6 +61,20 @@ feature "UserRegistrations" do
     assert_text 'El texto introducido no corresponde con el de la imagen'
   end
 
+  scenario "captcha skipped and another error", js: true do
+    visit new_user_registration_path
+    fill_in_personal_data(@user, @user.document_vatid)
+    fill_in_location_data(province: 'Barcelona',
+                          town: 'Barcelona',
+                          postal_code: '08021')
+    fill_in_login_data(@user, @user.email)
+    acknowledge_terms
+    acknowledge_age
+    click_button 'Inscribirse'
+    assert_text 'El texto introducido no corresponde con el de la imagen'
+    assert_text 'Acepto incribirme en la candidatura: debe ser aceptado'
+  end
+
   private
 
   def base_register(user)

--- a/test/features/user_registrations_test.rb
+++ b/test/features/user_registrations_test.rb
@@ -4,8 +4,6 @@ require "features/concerns/registration_helpers"
 feature "UserRegistrations" do
   include Participa::Test::RegistrationHelpers
 
-  before { @user = FactoryGirl.build(:user) }
-
   scenario "create a user in Catalonia", js: true do
     base_register(@user) do
       fill_in_location_data(country: 'España',
@@ -49,23 +47,18 @@ feature "UserRegistrations" do
     assert_equal true, User.first.gender_identity.cis_woman?
   end
 
-  scenario "captcha succeeds", js: true do
-    with_captcha_enabled do
-      visit new_user_registration_path
-      fill_in_user_registration(@user, @user.document_vatid, @user.email)
-      fill_in 'user[captcha]', with: SimpleCaptcha::SimpleCaptchaData.first.value
-      click_button 'Inscribirse'
-      assert_no_text 'El texto introducido no corresponde con el de la imagen'
-    end
-  end
-
-  scenario "captcha fails", js: true do
-    with_captcha_enabled do
-      visit new_user_registration_path
-      fill_in_user_registration(@user, @user.document_vatid, @user.email)
-      click_button 'Inscribirse'
-      assert_text 'El texto introducido no corresponde con el de la imagen'
-    end
+  scenario "captcha skipped", js: true do
+    visit new_user_registration_path
+    fill_in_personal_data(@user, @user.document_vatid)
+    fill_in_location_data(province: 'Barcelona',
+                          town: 'Barcelona',
+                          postal_code: '08021')
+    fill_in_login_data(@user, @user.email)
+    acknowledge_inscription
+    acknowledge_terms
+    acknowledge_age
+    click_button 'Inscribirse'
+    assert_text 'El texto introducido no corresponde con el de la imagen'
   end
 
   private

--- a/test/features/users_are_paranoid_test.rb
+++ b/test/features/users_are_paranoid_test.rb
@@ -4,8 +4,6 @@ require "features/concerns/registration_helpers"
 feature "UsersAreParanoid" do
   include Participa::Test::RegistrationHelpers
 
-  before { @user = FactoryGirl.build(:user) }
-
   scenario "regular registration", js: true do
     # first creation attempt, receive OK message and create it
     assert_equal 0, User.all.count

--- a/test/features/users_are_paranoid_test.rb
+++ b/test/features/users_are_paranoid_test.rb
@@ -4,34 +4,40 @@ require "features/concerns/registration_helpers"
 feature "UsersAreParanoid" do
   include Participa::Test::RegistrationHelpers
 
-  scenario "create a user", js: true do
-    user = FactoryGirl.build(:user)
+  before { @user = FactoryGirl.build(:user) }
 
+  scenario "regular registration", js: true do
     # first creation attempt, receive OK message and create it
     assert_equal 0, User.all.count
-    create_user_registration(user, user.document_vatid, user.email)
+    create_user_registration(@user, @user.document_vatid, @user.email)
     page.must_have_content I18n.t("devise.registrations.signed_up_but_unconfirmed")
     assert_equal 1, User.all.count
+  end
 
-    # second creation attempt, same document and email
+  scenario "creation with dup document and email", js: true do
+    @user.save!
     # receive OK message
     # but don't create the user and mail them a message
-    create_user_registration(user, user.document_vatid, user.email)
+    create_user_registration(@user, @user.document_vatid, @user.email)
     page.must_have_content I18n.t("devise.registrations.signed_up_but_unconfirmed")
     assert_equal 1, User.all.count
+  end
 
-    # third creation attempt, same document and invalid email
+  scenario "creation with same document and invalid email", js: true do
+    @user.save!
     # receive KO message
     # don't create it because it has errors.
     # should receive validation error.
-    create_user_registration(user, user.document_vatid, "trolololo")
+    create_user_registration(@user, @user.document_vatid, "trolololo")
     page.must_have_content "La dirección de correo es incorrecta"
     assert_equal 1, User.all.count
+  end
 
-    # third creation attempt, same document and different email
+  scenario "creation the same document and different email", js: true do
+    @user.save!
     # receive OK message
     # but don't create the user and mail them a message to original account
-    create_user_registration(user, user.document_vatid, "trolololo@example.com")
+    create_user_registration(@user, @user.document_vatid, "trolololo@example.com")
     page.must_have_content I18n.t("devise.registrations.signed_up_but_unconfirmed")
     assert_equal 1, User.all.count
   end


### PR DESCRIPTION
Currently if the user introduces a wrong captcha, and the form has other errors, only the captcha error will be displayed. So the user will fix the captcha, resubmit the form, and still fail to register. This PR fixes that by showing all errors, even when captcha is one of them.

Also some flaky tests are fixed.