### PR TITLE
Keep location on form resubmission

### DIFF
--- a/app/assets/javascripts/registrations.provinces_countries.js
+++ b/app/assets/javascripts/registrations.provinces_countries.js
@@ -57,22 +57,6 @@ function toggle_vote_town(country) {
 
 var can_change_vote_location;
 
-$.fn.flag_catalonian_residence = function() {
-  this.each(function() {
-    var $country = $('#user_country');
-    var $country_group = $country.parents('.inputlabel-box');
-
-    if (this.checked) {
-      show_provinces( 'ES', '1' );
-      $country.val('ES');
-      $country_group.hide();
-    } else {
-      show_provinces( $country.find(':selected').val(), '0' );
-      $country_group.show();
-    }
-  });
-};
-
 $(function() {
   can_change_vote_location = !$('select#user_vote_province').is(':disabled');
 
@@ -122,6 +106,13 @@ $(function() {
   }
 
   $catalonia_resident.click(function() {
-    $(this).flag_catalonian_residence();
+    if (this.checked) {
+      show_provinces( 'ES', '1' );
+      $country.val('ES');
+      $country_group.hide();
+    } else {
+      show_provinces( $country.find(':selected').val(), '0' );
+      $country_group.show();
+    }
   });
 });

--- a/app/assets/javascripts/registrations.provinces_countries.js
+++ b/app/assets/javascripts/registrations.provinces_countries.js
@@ -77,7 +77,7 @@ $(function() {
   can_change_vote_location = !$('select#user_vote_province').is(':disabled');
 
   var $country = $('select#user_country');
-  var $catalonia_resident = $('#catalonia_resident');
+  var $catalonia_resident = $('#user_catalonia_resident');
 
   if ($country.length) {
     $.fn.disable_control = function( ) {
@@ -115,7 +115,11 @@ $(function() {
     }
   }
 
-  $catalonia_resident.flag_catalonian_residence();
+  var $country_group = $country.parents('.inputlabel-box');
+
+  if ($catalonia_resident.is(':checked')) {
+    $country_group.hide();
+  }
 
   $catalonia_resident.click(function() {
     $(this).flag_catalonian_residence();

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -623,6 +623,7 @@ class User < ActiveRecord::Base
 
     # params from create page
     if params[:user]
+      user_location[:catalonia_resident] ||= cast_catalonia_resident(params[:user][:catalonia_resident])
       user_location[:country] ||= params[:user][:country]
       user_location[:province] ||= params[:user][:province]
       user_location[:town] ||= params[:user][:town]

--- a/config/locales/app.ca.yml
+++ b/config/locales/app.ca.yml
@@ -59,5 +59,3 @@ ca:
       email: "Correu electrònic"
       address: "Direcció"
       postal_code: "Codi postal"
-
-

--- a/test/features/user_registrations_test.rb
+++ b/test/features/user_registrations_test.rb
@@ -34,6 +34,15 @@ feature "UserRegistrations" do
     assert_location 'Alabama, Estados Unidos', User.first
   end
 
+  scenario "location is preserved upon form errors", js: true do
+    visit new_user_registration_path
+    fill_in_location_data(country: 'Estados Unidos', province: 'Alabama')
+    click_button 'Inscribirse'
+
+    assert page.has_select?('País', selected: 'Estados Unidos')
+    assert page.has_select?('Provincia', selected: 'Alabama')
+  end
+
   scenario "create a user with gender identity information", js: true do
     visit new_user_registration_path
     fill_in_user_registration(@user, @user.document_vatid, @user.email)

--- a/test/features/user_registrations_test.rb
+++ b/test/features/user_registrations_test.rb
@@ -28,8 +28,7 @@ feature "UserRegistrations" do
 
   scenario "create a user outside of Spain", js: true do
     base_register(@user) do
-      fill_in_location_data(country: 'Estados Unidos',
-                            province: 'Alabama')
+      fill_in_location_data(country: 'Estados Unidos', province: 'Alabama')
     end
 
     assert_location 'Alabama, Estados Unidos', User.first

--- a/vendor/overrides/encomu/app/views/devise/registrations/_form.html.erb
+++ b/vendor/overrides/encomu/app/views/devise/registrations/_form.html.erb
@@ -131,11 +131,13 @@
     <legend><span><%= t('domicilio') %></span></legend>
 
     <div class="inputlabel-box">
-      <%= label_tag :catalonia_resident,
-                    t('bec.registration.catalonia_resident') %>
+      <%= label :user, :catalonia_resident, class: "control-label" do %>
+        <%= t('bec.registration.catalonia_resident') %>
+      <% end %>
 
       <div class="input-box">
-        <%= check_box_tag :catalonia_resident, '1', true, class: 'checkbox' %>
+        <%= hidden_field_tag "user[catalonia_resident]", '0', id: nil %>
+        <%= check_box_tag "user[catalonia_resident]", '1', @user_location[:catalonia_resident], class: 'checkbox' %>
       </div>
     </div>
     <div class="inputlabel-box">

--- a/vendor/overrides/encomu/app/views/devise/registrations/_form.html.erb
+++ b/vendor/overrides/encomu/app/views/devise/registrations/_form.html.erb
@@ -145,7 +145,7 @@
           <%= field_notice_box %>
       <% end %>
       <%= label :user, :country, class: "control-label", required: :required do %>
-        País
+        <%= t('bec.registration.country') %>
         <abbr title="requerido">*</abbr>
       <% end %>
       <%= select_tag "user[country]", options_from_collection_for_select(get_countries, "code", "name", @user_location[:country]), { disabled: false, required: true, data: {allowClear: true} } %>

--- a/vendor/overrides/encomu/app/views/devise/registrations/_municipies_select.html.erb
+++ b/vendor/overrides/encomu/app/views/devise/registrations/_municipies_select.html.erb
@@ -1,11 +1,11 @@
 <div id="js-registration-user_town-wrapper" class="input required form-group">
   <%= label :user, :town, class: "control-label", required: :required do %>
-    Municipio
+    <%= t('bec.registration.town') %>
     <abbr title="requerido">*</abbr>
   <% end %>
     <span class="form-wrapper">
     <% towns = get_towns(@user_location[:country], @user_location[:province]) %>
-    <% placeholder = "-- Elige un municipio --" %>
+    <% placeholder = "-- #{t('bec.registration.choose_town')} --" %>
     <%= select_tag "user[town]", options_from_collection_for_select(towns, "code", "name", @user_location[:town]), {required: "required", data: {placeholder: placeholder}, prompt: placeholder } %>
     </span>
 </div>

--- a/vendor/overrides/encomu/app/views/devise/registrations/_subregion_select.html.erb
+++ b/vendor/overrides/encomu/app/views/devise/registrations/_subregion_select.html.erb
@@ -1,12 +1,12 @@
 <div id="js-registration-user_province-wrapper" class="input required form-group">
   <%= label :user, :province, class: "control-label", required: :required do %>
-    Provincia
+    <%= t('bec.registration.province') %>
     <abbr title="requerido">*</abbr>
   <% end %>
   <div class="form-wrapper">
   <% provinces = get_provinces(@user_location[:country],
                                @user_location[:catalonia_resident]) %>
-  <% placeholder = "-- Elige una provincia --" %>
+  <% placeholder = "-- #{t('bec.registration.choose_province')} --" %>
   <%= select_tag "user[province]", options_from_collection_for_select(provinces, "code", "name", @user_location[:province]), {required: "required", data: {placeholder: placeholder, allowClear: true}, prompt: placeholder } %>
   </div>
 </div>

--- a/vendor/overrides/encomu/config/locales/app.ca.yml
+++ b/vendor/overrides/encomu/config/locales/app.ca.yml
@@ -294,6 +294,11 @@ Quan es marca la casella 'He llegit i accepto les condicions generals' l'USUARI/
 <p> <b>Versió 28 de febrer de 2015 16:01 </b> </p> "
     registration:
       catalonia_resident: Resideixo a Catalunya
+      choose_province: Tria una província
+      choose_town: Tria un municipi
+      country: País
+      province: Província
+      town: Municipi
       legends:
         inscription_html: TODO
         legal1: TODO

--- a/vendor/overrides/encomu/config/locales/app.es.yml
+++ b/vendor/overrides/encomu/config/locales/app.es.yml
@@ -247,6 +247,11 @@ Al marcar la casilla “He leído y acepto las condiciones generales" el USUARIO
 '
     registration:
       catalonia_resident: "Resido en Cataluña"
+      choose_province: "Elige una provincia"
+      choose_town: "Elige un municipio"
+      country: "País"
+      province: "Provincia"
+      town: "Municipio"
       legends:
         inscription_html: "Inscribirse en Barcelona en Comú te da derecho a participar en todas las consultas y procesos participativos que se lancen en esta aplicación. No supone ninguna obligación económica, aunque puedes colaborar en este sentido si lo deseas. Aceptando, recibirás nuestros newsletters informativos. También puedes participar más, aquí puedes ver cómo hacerlo. <a href='https://barcelonaencomu.cat/es/participa' target='_blank' >https://barcelonaencomu.cat/es/participa </a> <br><br> BARCELONA EN COMÚ con personalidad jurídica propia, de acuerdo con la Ley Orgánica 6/2002, de 27 de junio, de Partidos Políticos, e inscrita en el Registro de Partidos Políticos con fecha 5 de febrero de 2015, Folio 488, Tomo VIII, CIF G66476136. Domicilio social: C. Castillejos, 233 (CP 08013 BARCELONA). Telèfon: 935.321.796. "
         legal1: Véase la política de privacidad


### PR DESCRIPTION
Fixes location information already introduced being lost upon form errors.

Since I was at it, added some missing translations too.