### PR TITLE
Resend confirmation emails to Microsoft users

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,9 @@ Style/ExtraSpacing:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
+Style/Lambda:
+  EnforcedStyle: literal
+
 Performance/Casecmp:
   Enabled: false
 

--- a/lib/tasks/encomu/confirm_microsoft.rake
+++ b/lib/tasks/encomu/confirm_microsoft.rake
@@ -1,0 +1,38 @@
+require 'tasks/encomu/confirmation_extensions'
+
+namespace :encomu do
+  desc "[encomu] Resend confirmations for Microsoft users"
+  task :confirm_microsoft => :environment do
+    User.include(ConfirmationExtensions)
+
+    target = User.confirmation_sent_before(DateTime.new(2016,12,27)).microsoft
+
+    if target.none?
+      raise "No Microsoft users left to be sent a confirmation email"
+    end
+
+    already_confirmed = target.where.not(confirmed_at: nil)
+
+    if already_confirmed.any?
+      raise <<~MSG
+        The following target users are already confirmed, so emails
+        shoudn't be sent to them:
+
+        #{already_confirmed.pluck(:email).join("\n")}
+      MSG
+    end
+
+    STDOUT.print <<~MSG.strip
+
+      About to resend confirmation email to:
+
+      #{target.pluck(:email).join("\n")}
+
+      Continue? (y/n)
+    MSG
+
+    abort unless STDIN.gets.chomp == 'y'
+
+    target.each(&:send_confirmation_instructions)
+  end
+end

--- a/lib/tasks/encomu/confirmation_extensions.rb
+++ b/lib/tasks/encomu/confirmation_extensions.rb
@@ -1,0 +1,11 @@
+module ConfirmationExtensions
+  def self.included(base)
+    base.class_eval do
+      scope :microsoft, -> { where("email ~ '@(live|hotmail|outlook)\..*'") }
+
+      scope :confirmation_sent_before, ->(date) do
+        where('confirmation_sent_at < ?', date.to_s(:db))
+      end
+    end
+  end
+end

--- a/test/lib/microsoft_confirmations_test.rb
+++ b/test/lib/microsoft_confirmations_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+require 'tasks/encomu/confirmation_extensions'
+
+class MicrosoftConfirmationsTest < ActiveSupport::TestCase
+  setup { User.include(ConfirmationExtensions) }
+
+  test ".microsoft" do
+    emails = %w(
+      example@outlook.es
+      peter@outlook.com
+      peter@gmail.com
+      peter@yahoo.fr
+      more@live.com
+      example@hotmail.es
+      example@hotmail.com
+    )
+
+    emails.each { |email| FactoryGirl.create(:user, email: email) }
+
+    assert_equal emails - %w(peter@gmail.com peter@yahoo.fr),
+                 User.microsoft.pluck(:email)
+  end
+
+  test ".confirmation_sent_before" do
+    FactoryGirl.create(:user, confirmation_sent_at: 2.hours.ago)
+    user = FactoryGirl.create(:user, confirmation_sent_at: 4.hours.ago)
+
+    assert_equal [user], User.confirmation_sent_before(3.hours.ago)
+  end
+end


### PR DESCRIPTION
Adds a task to resend unreceived confirmations.

The first attempt has these conditions:
* Only "live", "outlook" or "homail" addresses.
* Only users registered before we fixed the problem.

If the scopes are defined correctly, they should all be unconfirmed. If this is not the case, the task will raise with an informative message. 

Before sending the emails, the target list of email addresses will be displayed and confirmation will be required before proceeding.

One concern is whether we should add some delay between sending each email. Just in case Microsoft doesn't like that we send a lot of emails in a short period of time? Not sure. @andreslucena ?