### PR TITLE
Enable verificator management unconditionally

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -283,10 +283,8 @@ ActiveAdmin.register User do
     end
   end
 
-  if Rails.application.secrets.features["verification_presencial"]
-    action_item(:edit, :only => :show) do
-      link_to('Perfil de Verificador', edit_admin_verifier_profile_path(user))
-    end
+  action_item(:edit, :only => :show) do
+    link_to('Perfil de Verificador', edit_admin_verifier_profile_path(user))
   end
 
   action_item(:restore, only: :show) do


### PR DESCRIPTION
This should be always available. As a matter of fact, it's something you
need available before activating the feature it was being hidden by.

A sane PR for you to review @andreslucena :gift:, sorry for the previous one :flushed: .