### PR TITLE
Always allow admins to see the verifications map

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -26,6 +26,8 @@ class Ability
         cannot :manage, SpamFilter
         can :read, Election
       end
+
+      can :show, :verification
     else
       cannot :manage, :all
       cannot :manage, Resque

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,10 +127,11 @@ Rails.application.routes.draw do
         get '/ok', to: 'verification#result_ok', as: :verification_result_ok
         get '/ko', to: 'verification#result_ko', as: :verification_result_ko
       end
-      scope '/verificaciones' do 
-        get '/', to: 'verification#show', as: :verification_show
-      end
     end    
+
+    scope '/verificaciones' do 
+      get '/', to: 'verification#show', as: :verification_show
+    end
 
     %w(404 422 500).each do |code|
       get code, to: 'errors#show', code: code


### PR DESCRIPTION
It's nice for admins to be able to see how the map looks like before enabling the feature.

The better solution here would to actually show a preview of the map in
the administration site itself, but I don't want to spend more time on
this, so I think this works for now.