### PR TITLE
Styling election pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,3 @@ before_script:
   - bundle exec rake db:migrate
 
 script: bundle exec rake test
-
-branches:
-  only:
-    - master

--- a/app/views/layouts/full.html.erb
+++ b/app/views/layouts/full.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title><%= yield :title %> | BComú</title>
+  <title><%= yield :title %> | Un País En Comú</title>
   <meta name="globalsign-domain-verification" content="jWUMrdTC0yyEo-WRh7KwWE1x4bjogM-RFYNZp6ZIbL" /> 
   <link rel="shortcut icon" href="<%= image_path("favicon.png") %>" type="image/png">
   <link rel="icon" href="<%= image_path("favicon.png") %>" type="image/png">

--- a/app/views/layouts/full.html.erb
+++ b/app/views/layouts/full.html.erb
@@ -14,6 +14,7 @@
   <div class="container">
     <%= render partial: 'header' %>
     <%= yield %>
+    <%= render partial: 'footer' %>
     <%= render partial: 'analytics' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   </div>

--- a/app/views/layouts/full.html.erb
+++ b/app/views/layouts/full.html.erb
@@ -11,9 +11,11 @@
   <%= csrf_meta_tags %>
 </head>
 <body class="<%= body_class user_signed_in?, controller_name, action_name %>">
+  <div class="container">
     <%= render partial: 'header' %>
     <%= yield %>
     <%= render partial: 'analytics' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
@andreslucena I had a quick look at elections & voting and added some visual fixes.

* The page title in the elections layout was set to BComu.
* The layout breaks when entering the voting page: the menu and content become full width and the footer disappears. I'm not sure if the agora voting js embedding the voting page needs some special structure, but this certainly integrates better with the rest of the site.

What do you think?