### PR TITLE
Prevent AA bug by pinning to older version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,12 @@ gem 'spanish_vat_validators', github: 'deivid-rodriguez/spanish_vat_validators',
 gem 'simple_captcha2', require: 'simple_captcha'
 gem 'carmen-rails'
 gem 'esendex'
-gem 'activeadmin', github: 'activeadmin'
+
+#
+# @todo: activeadmin/activeadmin#4477 broke our "new verification center" page,
+# so I'm pinning AA to the commit prior to that change. Report the bug to AA.
+#
+gem 'activeadmin', github: 'activeadmin', ref: 'e7c3d8cfc7ec3aeaf6893588068dbcd9bd2744f7'
 gem 'active_skin'
 
 gem 'resque', github: 'resque/resque', require: 'resque/server'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,10 @@
 GIT
   remote: https://github.com/activeadmin/activeadmin.git
-  revision: b362775aa85df4ca542c136be79e1ac1240167af
+  revision: e7c3d8cfc7ec3aeaf6893588068dbcd9bd2744f7
+  ref: e7c3d8cfc7ec3aeaf6893588068dbcd9bd2744f7
   specs:
     activeadmin (1.0.0.pre5)
-      arbre (>= 1.1.1)
+      arbre (~> 1.0, >= 1.0.2)
       bourbon
       coffee-rails
       formtastic (~> 3.1)


### PR DESCRIPTION
Recent Active Admin upgrade broke our "new verification center" page. Maybe the most actively used at the moment...

Pinning ourselves to an older version that does not experience the bug.