### PR TITLE
Fix maximum allowed registration year

### DIFF
--- a/app/views/devise/registrations/_form.html.erb
+++ b/app/views/devise/registrations/_form.html.erb
@@ -78,7 +78,7 @@
                   fragment_classes: { year: 'col-year', month: 'col-month', day: 'col-day' },
                   fragment_placeholders: { year: 'año', month: 'mes', day: 'día' },
                   input_html: { required: true, class: 'input-s' },
-                  start_year: 1999,
+                  start_year: 16.years.ago.year,
                   end_year: 1900 %>
     </div>
 

--- a/test/integration/concerns/registration_helpers.rb
+++ b/test/integration/concerns/registration_helpers.rb
@@ -83,9 +83,13 @@ module Participa
         fill_in('Apellidos', :with => user.last_name)
         select("Pasaporte", from: "Tipo de documento")
         fill_in('DNI', :with => document_vatid)
-        select("1970", from: "user[born_at(1i)]")
-        select("enero", from: "user[born_at(2i)]")
-        select("1", from: "user[born_at(3i)]")
+        fill_in_born_date("1970", "enero", "1")
+      end
+
+      def fill_in_born_date(year, month, day)
+        select(year, from: "user[born_at(1i)]")
+        select(month, from: "user[born_at(2i)]")
+        select(day, from: "user[born_at(3i)]")
       end
     end
   end

--- a/test/integration/user_registrations_test.rb
+++ b/test/integration/user_registrations_test.rb
@@ -25,6 +25,27 @@ class UserRegistrationsTest < JsFeatureTest
     assert User.first.vegueria_code, 'AT01'
   end
 
+  test "allows the youngest (16 years old) to register" do
+    user = build(:user, born_at: 16.years.ago)
+    visit new_user_registration_path
+    fill_in('Nombre', with: user.first_name)
+    fill_in('Apellidos', with: user.last_name)
+    select("Pasaporte", from: "Tipo de documento")
+    fill_in('DNI', with: user.document_vatid)
+
+    fill_in_born_date(user.born_at.year,
+                      I18n.l(user.born_at, format: "%B"),
+                      user.born_at.day)
+
+    fill_in_location_data(user)
+    fill_in_login_data(user, user.email)
+    acknowledge_stuff
+    click_button "Inscribirse"
+
+    assert_content \
+      I18n.t("devise.registrations.signed_up_but_unconfirmed")
+  end
+
   test "create a user outside of Catalonia" do
     @user = build(:user, :spanish, province: 'AB',
                                    town: 'm_02_003_0',


### PR DESCRIPTION
This could definitely be improved:

* Use a calendar.
* Disable all invalid dates.
* Unify logic server & client side.

But for now I just want our kids to be able to register. :stuck_out_tongue: 