### PR TITLE
Presential verifications hotfix

### DIFF
--- a/app/controllers/verification_controller.rb
+++ b/app/controllers/verification_controller.rb
@@ -37,7 +37,7 @@ class VerificationController < ApplicationController
       @user = User.find_by_email(params[:user][:email])
       if @user
         if @user.is_verified_presentially? 
-          flash.now[:notice] = t('verification.alerts.already_presencial', document: @user.document_vatid, by: @user.verified_by.full_name, when: @user.verified_at)
+          flash.now[:notice] = already_verified_alert
           render :step2
         else
           render :step3
@@ -62,4 +62,11 @@ class VerificationController < ApplicationController
     end
   end
 
+  private
+
+  def already_verified_alert
+    t('verification.alerts.already_presencial', document: @user.document_vatid,
+                                                by: @user.verified_by.full_name,
+                                                when: @user.verified_at)
+  end
 end

--- a/app/controllers/verification_controller.rb
+++ b/app/controllers/verification_controller.rb
@@ -34,7 +34,7 @@ class VerificationController < ApplicationController
   def search
     authorize! :search, :verification
     if params[:user]
-      @user = User.find_by_email(params[:user][:email]) # || User.find_by_document_vatid(params[:user][:document_vatid])
+      @user = User.find_by_email(params[:user][:email])
       if @user
         if @user.is_verified_presentially? 
           flash.now[:notice] = t('verification.alerts.already_presencial', document: @user.document_vatid, by: @user.verified_by.full_name, when: @user.verified_at)

--- a/app/controllers/verification_controller.rb
+++ b/app/controllers/verification_controller.rb
@@ -39,6 +39,10 @@ class VerificationController < ApplicationController
         if @user.is_verified_presentially? 
           flash.now[:notice] = already_verified_alert
           render :step2
+        elsif @user.confirmed_at.nil?
+          @user.send_confirmation_instructions
+          flash.now[:alert] = unconfirmed_email_alert
+          render :step2
         else
           render :step3
         end
@@ -68,5 +72,9 @@ class VerificationController < ApplicationController
     t('verification.alerts.already_presencial', document: @user.document_vatid,
                                                 by: @user.verified_by.full_name,
                                                 when: @user.verified_at)
+  end
+
+  def unconfirmed_email_alert
+    t('verification.alerts.unconfirmed_html', email: @user.email).html_safe
   end
 end

--- a/app/views/verification/step1.html.erb
+++ b/app/views/verification/step1.html.erb
@@ -30,7 +30,7 @@
           <div class="inputlabel-box">
             <input class="checkbox" id="user_age_restriction" name="user[age_restriction]" value="1" required="true" type="checkbox">
             <label for="user_age_restriction">
-              <%= t('verification.form.age', date: l( Date.today - 16.years ) ) %>
+              <%= t('verification.form.age', date: l(16.years.ago) ) %>
             </label>
           </div>
 

--- a/app/views/verification/step2.html.erb
+++ b/app/views/verification/step2.html.erb
@@ -17,12 +17,6 @@
 
           <fieldset class="verification-form">
 
-            <!-- div class="inputlabel-box">
-              <div class="input-box">
-                <%# f.input :document_vatid, required: false, label: t('verification.document') %>
-              </div>
-            </div -->
-
             <div class="inputlabel-box">
               <div class="input-box">
                 <%= f.input :email, required: true, as: :email, label: t('verification.email') %>

--- a/config/locales/app.ca.yml
+++ b/config/locales/app.ca.yml
@@ -482,7 +482,9 @@ Conforme a allò convingut a l'article 16.3 de la Llei Orgànica de Protecció d
     step3: Comprova
     welcome_html: "<p>Demana-li amablement a l'usuari/ària els documents que ha d'haver portat. S'haurien de complir els requisits següents:</p>"
     next: Següent
-    confirm: Confirma
+    next_user: Continuar amb el següent usuari
+    confirm: Sí, aquestes dades coincideixen
+    no_confirm: No, aquestes dades no coincideixen
     new: "Escriu en el fomulari següent el document o correu electrònic amb què s'ha inscrit"
     document: "DNI/NIE/Passaport"
     full_name: Nom complet
@@ -494,7 +496,12 @@ Conforme a allò convingut a l'article 16.3 de la Llei Orgànica de Protecció d
     admin: Gestor de verificacions presencials
     alerts:
       already_presencial: "L'usuari/ària amb document %{document} ja estava  verificat, per %{by}, el %{when}. L'usuari/ària ja podrà votar."
-      ok: "S'ha verificat l'usuari/ària correctament. Li hem enviat un  correu avisant-lo. Podrà votar en les pròximes votacions. Pots  continuar amb el següent usuari/ària."
+      ok:
+        title: "S'ha verificat l'usuari/ària correctament"
+        msg_html: "La persona ha estat verificada correctament. Li hem enviat un correu avisant-li. Podrà votar en futures votacions. Pots verificar al següent usuari."
+      ko:
+        title: "No s'ha verificat a l'usuari."
+        msg_html: "No podrà votar en les properes consultes. Envia-li un Telegram al Coordinador del teu districte amb les dades (nom, correu electrònic i DNI) de l'usuari perquè ho revisi. Informa a l'usuari que ens posarem en contacte amb ell o ella al més aviat possible."
       unconfirmed_html: >
         La persona amb l'email <b>%{email}</b> no ha confirmat el seu correu
         electrònic. Li acabem d'enviar un mail de confirmació ara mateix

--- a/config/locales/app.ca.yml
+++ b/config/locales/app.ca.yml
@@ -495,6 +495,10 @@ Conforme a allò convingut a l'article 16.3 de la Llei Orgànica de Protecció d
     alerts:
       already_presencial: "L'usuari/ària amb document %{document} ja estava  verificat, per %{by}, el %{when}. L'usuari/ària ja podrà votar."
       ok: "S'ha verificat l'usuari/ària correctament. Li hem enviat un  correu avisant-lo. Podrà votar en les pròximes votacions. Pots  continuar amb el següent usuari/ària."
+      unconfirmed_html: >
+        La persona amb l'email <b>%{email}</b> no ha confirmat el seu correu
+        electrònic. Li acabem d'enviar un mail de confirmació ara mateix
+        perquè pugui confirmar el seu correu, verificar-se i votar
       not_found: "No hem trobat un usuari/ària amb aquest document o correu electrònic. Búsqueda: %{query1} %{query2}"
       problem: "Hi ha hagut un problema buscant aquest usuari/ària. Fes una foto al document, demana-li el seu correu electrònc i envia'l a  info@unpaisencomu.cat"
     mailer:

--- a/config/locales/app.es.yml
+++ b/config/locales/app.es.yml
@@ -887,6 +887,10 @@ De conformidad con lo dispuesto en el artículo 16.3 de la Ley Orgánica de Prot
       ko:
         title: No se ha verificado al usuario.
         msg_html: "No va a poder votar en las próximas consultas. Envíale un Telegram al Coordinador de tu distrito con los datos (nombre, correo electrónico y DNI) del usuario para que lo revise. Informa al usuario que nos pondremos en contacto con él o ella lo más pronto posible."
+      unconfirmed_html: >
+        La persona con email <b>%{email}</b> no ha confirmado su correo
+        electrónico. Le acabamos de enviar un nuevo correo de confirmación para
+        que pueda confirmar su correo, verificarse y votar.
       not_found: "No hemos encontrado un usuario/a con este correo electrónico %{query1} %{query2}. Presta atención y vuelve a escribir el correo. Si vuelve a ocurrir puede ser que el usuario no esté creado en el sistema o haya algún problema con su cuenta. Enviale sus datos al Responsable de tu Distrito para que lo revisemos. Ya lo contactaremos. "
       problem: "No está inscrito/a, se inscribió con otro correo o escribió mal el correo al inscribirse. Envía a tu verificador vía Telegram la siguiente información: DNI
 Número de teléfono y correo electrónico y comunícale que nos pondremos en contacto con el o ella."

--- a/test/integration/verification_presencial_test.rb
+++ b/test/integration/verification_presencial_test.rb
@@ -68,18 +68,18 @@ class VerificationPresencialTest < JsFeatureTest
   end
 
   test "presential verifiers can verify users presentially" do
-    user2 = create(:user)
+    user = create(:user)
 
-    # user1 can verify user2
-    user1 = create(:user, :verifying_presentially)
-    login(user1)
+    # verification can verify user
+    verificator = create(:user, :verifying_presentially)
+    login(verificator)
     visit verification_step1_path
     assert_content I18n.t('verification.form.document')
     check('user_document')
     check('user_town')
     check('user_age_restriction')
     click_button('Siguiente')
-    fill_in(:user_email, with: user2.email)
+    fill_in(:user_email, with: user.email)
     click_button('Siguiente')
     assert_content I18n.t('verification.result')
     click_button('Si, estos datos coinciden')
@@ -87,7 +87,7 @@ class VerificationPresencialTest < JsFeatureTest
     logout
 
     # should see the OK verification message
-    login(user2)
+    login(user)
     assert_content I18n.t('voting.election_none')
   end
 end


### PR DESCRIPTION
This fixes the issue of allowing presential verifications of users with unconfirmed emails. Instead, we resend the confirmation email to the user and show an informational message to the verificator.

Also includes some translations & cleanups.