### PR TITLE
Hide doc upload unless user needs reupload

### DIFF
--- a/app/models/concerns/verificable.rb
+++ b/app/models/concerns/verificable.rb
@@ -130,7 +130,7 @@ module Verificable
   def pending_docs?
     return false unless Features.online_verifications? && not_banned?
 
-    verification_events.none? || verification_events.last_was_report?
+    verification_events.any? && verification_events.last_was_report?
   end
 
   def pending_moderation?

--- a/config/locales/app.es.yml
+++ b/config/locales/app.es.yml
@@ -525,7 +525,7 @@ es:
     change_email_explain: "Si cambias tu correo electrónico te enviaremos otro correo para que lo confirmes."
     change_phone: "Cambiar teléfono móvil"
     change_phone_explain_html: "Te has validado con el teléfono móvil <b>%{unprefixed_phone}</b> de <b>%{phone_country}</b> (prefijo internacional %{phone_prefix})."
-    change_documents: "Mis Documentos"
+    change_documents: "Mis documentos"
     change_documents_explain: >
       Esta es la lista de imágenes que nos has facilitado para el proceso de
       verificación digital. Si hay errores en tu solicitud inicial, o te falta

--- a/test/integration/profile_editions_test.rb
+++ b/test/integration/profile_editions_test.rb
@@ -30,6 +30,14 @@ class ProfileEditionsTest < JsFeatureTest
     assert_title "Datos personales"
   end
 
+  test "users not having started online verification can't see documents tab" do
+    with_verifications(online: true) do
+      click_link "Datos personales"
+
+      refute_content "MIS DOCUMENTOS"
+    end
+  end
+
   test "form errors preserve changed data" do
     click_link "Datos personales"
     select "Brasil", from: "País"

--- a/test/models/concerns/verificable_test.rb
+++ b/test/models/concerns/verificable_test.rb
@@ -72,7 +72,7 @@ class VerifiableTest < ActiveSupport::TestCase
 
   test "online verification process status" do
     confirmed_by_sms_only = create(:user, :confirmed_by_sms)
-    assert_equal true, confirmed_by_sms_only.pending_docs?
+    assert_equal false, confirmed_by_sms_only.pending_docs?
     assert_equal false, confirmed_by_sms_only.pending_moderation?
 
     ready_for_review = create(:user, :pending_moderation)

--- a/test/models/concerns/verificable_test.rb
+++ b/test/models/concerns/verificable_test.rb
@@ -71,7 +71,6 @@ class VerifiableTest < ActiveSupport::TestCase
   end
 
   test "online verification process status" do
-    # pathologic, shouldn't happen in real life but data is data, you never know
     confirmed_by_sms_only = create(:user, :confirmed_by_sms)
     assert_equal true, confirmed_by_sms_only.pending_docs?
     assert_equal false, confirmed_by_sms_only.pending_moderation?


### PR DESCRIPTION
While fixing #90, I noticed that the documents tab is incorrectly displayed (and with a not very good design) when the user hasn't yet started the online verification process.

This tab is only meant to show up when the user need to amend her documentation because it was initially incorrect.

I don't think this is likely to cause any issue, but it's better to fix it because that tab can be confusing in those situations.