### PR TITLE
Tiny visual fix in registration form

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -264,17 +264,17 @@ fieldset .inputlabel-box p, fieldset .inputlabel-box li{
   margin:0;
 }
 
-fieldset .inputlabel-box ul{
+.gender-list {
   list-style-type: circle;
+
+  li {
+    font-size: 1.3em;
+    list-style: inside;
+  }
 }
-fieldset .inputlabel-box li{
-  list-style: inside;
-}
+
 fieldset .inputlabel-box ul.terms-links li{
   list-style: none;
-}
-fieldset .inputlabel-box ul.info-list li{
-  font-size: 1.3em;
 }
 fieldset .alert-nexttolabel{
   display:inline-block;

--- a/app/views/devise/registrations/_form.html.erb
+++ b/app/views/devise/registrations/_form.html.erb
@@ -89,7 +89,7 @@
     <div class="inputlabel-box">
       <label class="control-label"></label>
       <div class="form-wrapper">
-        <ul class="info-list">
+        <ul class="gender-list">
           <% %w(cis trans fluid).each do |term| %>
             <li>
               <strong><%= t("registration.legends.#{term}_key") %></strong>:


### PR DESCRIPTION
Double list markers are currently being displayed.

![doubleliststyles](https://cloud.githubusercontent.com/assets/2887858/24710883/d32d887a-19f4-11e7-8f8e-aeb0eb9b73c2.png)
