### PR TITLE
Mail to unconfirmed

### DIFF
--- a/app/mailers/confirmation_mailer.rb
+++ b/app/mailers/confirmation_mailer.rb
@@ -6,8 +6,7 @@ class ConfirmationMailer < ActionMailer::Base
     @user = user
     @token = user.confirmation_token
 
-    subject = 'Un País En Comú - Re-envío de la confirmación / ' \
-              'Re-enviament de la confirmació'
+    subject = '[Un País en Comú - ATENCIÓ] Si no confirmes el teu correu, no podràs participar!'
 
     mail(to: user.email, subject: subject)
 

--- a/app/views/confirmation_mailer/retry_confirmation_instructions.html.erb
+++ b/app/views/confirmation_mailer/retry_confirmation_instructions.html.erb
@@ -1,9 +1,9 @@
-<% [%w(Castellano es), %w(Catatá ca)].each do |language, locale| %>
-  <p><strong><%= language.to_s %></strong></p>
+<% %w(ca es).each do |locale| %>
+  <p><%= t(".hello", user: @user.first_name, locale: locale) %></p>
 
-  <p><%= t('.hello', user: @user.full_name, locale: locale) %></p>
+  <p><%= t(".explanation", locale: locale) %></p>
 
-  <p><%= t('.explanation', locale: locale) %></p>
+  <p><%= t(".instructions", locale: locale) %></p>
 
   <p>
     <% url = confirmation_url(@user,
@@ -12,11 +12,9 @@
     <%= link_to url, url %>
   </p>
 
-  <p><%= t('.ignore', locale: locale) %></p>
+  <p><%= t(".apologize", locale: locale) %></p>
 
-  <p><%= t('.bye', locale: locale) %></p>
-
-  <% if locale == 'es' %>
+  <% if locale == 'ca' %>
     <hr>
   <% end %>
 <% end %>

--- a/app/views/confirmation_mailer/retry_confirmation_instructions.text.erb
+++ b/app/views/confirmation_mailer/retry_confirmation_instructions.text.erb
@@ -1,20 +1,19 @@
-<% [%w(Castellano es), %w(Catatá ca)].each do |language, locale| %>
-  <%= "------ #{language} ------" %>
-
-  <%= t('.hello', user: @user.full_name, locale: locale) %>
+<% %w(ca es).each do |locale| %>
+  <%= t('.hello', user: @user.first_name, locale: locale) %>
 
   <%= t('.explanation', locale: locale) %>
+
+  <%= t('.instructions', locale: locale) %>
 
   <% url = confirmation_url(@user, confirmation_token: @token, locale: locale) %>
   <%= link_to url, url %>
 
   <%= url.to_s %>
 
-  <%= t('.ignore', locale: locale) %>
+  <%= t('.apologize', locale: locale) %>
 
-  <%= t('.bye', locale: locale) %>
-
-  <% if locale == 'es' %>
+  <% if locale == 'ca' %>
+    ----------------------------------------------------------------------------
 
   <% end %>
 <% end %>

--- a/config/locales/app.ca.yml
+++ b/config/locales/app.ca.yml
@@ -3,6 +3,17 @@ ca:
     flatpickr_code: "cat"
     language: "Idioma"
     language_name: "Català"
+  confirmation_mailer:
+    retry_confirmation_instructions:
+      hello: "Hola, %{user}:"
+      explanation: >-
+        A causa d'alguns problemes en la recepció de correus electrònics, estem
+        re-enviant el correu de confirmació a persones que creiem que poden no
+        haver-ho rebut. Per confirmar el teu compte fes clic al següent enllaç:
+      ignore: >-
+        Si ja vas rebre aquest email però havies decidit no confirmar el teu
+        compte, pots ignorar aquest missatge.
+      bye: Salutacions!
   home:
     signup_title: Inscriu-te per poder votar
   activerecord:

--- a/config/locales/app.ca.yml
+++ b/config/locales/app.ca.yml
@@ -7,13 +7,15 @@ ca:
     retry_confirmation_instructions:
       hello: "Hola, %{user}:"
       explanation: >-
-        A causa d'alguns problemes en la recepció de correus electrònics, estem
-        re-enviant el correu de confirmació a persones que creiem que poden no
-        haver-ho rebut. Per confirmar el teu compte fes clic al següent enllaç:
-      ignore: >-
-        Si ja vas rebre aquest email però havies decidit no confirmar el teu
-        compte, pots ignorar aquest missatge.
-      bye: Salutacions!
+        Hem detectat que no has confirmat el teu correu. Hi ha hagut diversos
+        problemes tècnics aliens a la nostra voluntat, per això hem volgut
+        escriure't per assegurar-nos que has rebut el correu de confirmació.
+      instructions: >-
+        Confirma el teu correu clicant al link següent per poder seguir amb el
+        procés de votació d'Un País en Comú, així com per poder accedir a
+        l'Assemblea d'aquest cap de setmana!
+      apologize: >-
+        Si no ha sigut el teu cas, et demanem disculpes per aquest correu.
   home:
     signup_title: Inscriu-te per poder votar
   activerecord:

--- a/config/locales/app.es.yml
+++ b/config/locales/app.es.yml
@@ -8,6 +8,18 @@ es:
       es: "español"
       eu: "vasco"
       ga: "gallego"
+  confirmation_mailer:
+    retry_confirmation_instructions:
+      hello: "Hola, %{user}:"
+      explanation: >-
+        Debido a algunos problemas en la recepción de correos electrónicos,
+        estamos reenviando el correo de confirmación a personas que creemos que
+        pueden no haberlo recibido. Para confirmar tu cuenta haz click en el
+        siguiente enlace:
+      ignore: >-
+        Si ya recibiste este email pero habías decidido no confirmar tu cuenta,
+        puedes ignorar este mensaje.
+      bye: Saludos!
   home:
     signup_title: Inscríbete para poder votar
   errors:

--- a/config/locales/app.es.yml
+++ b/config/locales/app.es.yml
@@ -12,14 +12,15 @@ es:
     retry_confirmation_instructions:
       hello: "Hola, %{user}:"
       explanation: >-
-        Debido a algunos problemas en la recepción de correos electrónicos,
-        estamos reenviando el correo de confirmación a personas que creemos que
-        pueden no haberlo recibido. Para confirmar tu cuenta haz click en el
-        siguiente enlace:
-      ignore: >-
-        Si ya recibiste este email pero habías decidido no confirmar tu cuenta,
-        puedes ignorar este mensaje.
-      bye: Saludos!
+        Hemos detectado que no has confirmado tu correo. Ha habido varios
+        problemas técnicos ajenos a nuestra voluntad, por eso hemos querido
+        escribirte para asegurarnos de que recibes el correo de confirmación.
+      instructions: >-
+        Confirma tu correo clicando en el enlace siguiente para poder seguir con
+        el proceso de votación de Un País en común, así como para poder acceder
+        a la Asamblea de este fin de semana!
+      apologize: >-
+        Si no ha sido tu caso, te pedimos disculpas por este correo.
   home:
     signup_title: Inscríbete para poder votar
   errors:

--- a/lib/tasks/encomu/retry_confirmation_instructions.rake
+++ b/lib/tasks/encomu/retry_confirmation_instructions.rake
@@ -4,7 +4,7 @@ namespace :encomu do
     target = if args[:mlist].present?
                User.where(email: args[:mlist].split(','))
              else
-               User.where(confirmed_at: nil)
+               User.where('confirmed_at is NULL AND confirmation_sent_at < ?', 1.day.ago)
              end
 
     if target.none?

--- a/lib/tasks/encomu/retry_confirmation_instructions.rake
+++ b/lib/tasks/encomu/retry_confirmation_instructions.rake
@@ -4,9 +4,7 @@ namespace :encomu do
     target = if args[:mlist].present?
                User.where(email: args[:mlist].split(','))
              else
-               User.where <<-SQL.squish, Time.zone.local(2016, 12, 27)
-                 confirmed_at IS NULL AND confirmation_sent_at < ?
-               SQL
+               User.where(confirmed_at: nil)
              end
 
     if target.none?

--- a/vendor/overrides/encomu/config/locales/app.ca.yml
+++ b/vendor/overrides/encomu/config/locales/app.ca.yml
@@ -7,17 +7,6 @@ ca:
         trans_man: Home (trans)
         trans_woman: Dona (trans)
         fluid: Gènere No-binari
-  confirmation_mailer:
-    retry_confirmation_instructions:
-      hello: "Hola, %{user}:"
-      explanation: >-
-        A causa d'alguns problemes en la recepció de correus electrònics, estem
-        re-enviant el correu de confirmació a persones que creiem que poden no
-        haver-ho rebut. Per confirmar el teu compte fes clic al següent enllaç:
-      ignore: >-
-        Si ja vas rebre aquest email però havies decidit no confirmar el teu
-        compte, pots ignorar aquest missatge.
-      bye: Salutacions!
   errors:
     show:
       "404":

--- a/vendor/overrides/encomu/config/locales/app.es.yml
+++ b/vendor/overrides/encomu/config/locales/app.es.yml
@@ -7,18 +7,6 @@ es:
         trans_man: Hombre (trans)
         trans_woman: Mujer (trans)
         fluid: Género No-binario
-  confirmation_mailer:
-    retry_confirmation_instructions:
-      hello: "Hola, %{user}:"
-      explanation: >-
-        Debido a algunos problemas en la recepción de correos electrónicos,
-        estamos reenviando el correo de confirmación a personas que creemos que
-        pueden no haberlo recibido. Para confirmar tu cuenta haz click en el
-        siguiente enlace:
-      ignore: >-
-        Si ya recibiste este email pero habías decidido no confirmar tu cuenta,
-        puedes ignorar este mensaje.
-      bye: Saludos!
   errors:
     show:
       "404":


### PR DESCRIPTION
Send one more email prompting for email confirmation.

After all email deliverability & and link visibility problems, it was decided to send one last email encouraging email confirmation. This is critical: unconfirmed account won't be able to vote.