### PR TITLE
Improvements in users experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ app/assets/fonts/StagStencil-Bold-Web.woff2
 /public/system
 
 db/*.sqlite3
+
+# Ignore byebug history
+.byebug_history

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -262,7 +262,7 @@ ActiveAdmin.register User do
       column :last_name
       column :document_type_name
       column :document_vatid
-      column :phone
+      column(:phone) { |user| user.phone.gsub("0034","") }
     end
 
     column :postal_code

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -262,7 +262,7 @@ ActiveAdmin.register User do
       column :last_name
       column :document_type_name
       column :document_vatid
-      column(:phone) { |user| user.phone.gsub("0034","") }
+      column(:phone) { |user| user.phone.gsub(/\A0034/,"") }
     end
 
     column :postal_code

--- a/app/assets/stylesheets/general.scss
+++ b/app/assets/stylesheets/general.scss
@@ -390,6 +390,20 @@ tools
   margin-top: 30px;
 }
 
+.election-box{
+  margin-bottom: 2rem;
+  h2{
+    font-size: 1.8rem;
+    line-height: 1rem;
+  }
+  .poll-q{
+    text-transform: uppercase;
+  }
+  .date{
+    font-size: 1rem;
+  }
+}
+
 /* -----------------------------------
 microcredits
 ----------------------------------- */

--- a/app/controllers/verification_controller.rb
+++ b/app/controllers/verification_controller.rb
@@ -26,7 +26,7 @@ class VerificationController < ApplicationController
   def search
     authorize! :search, :verification
 
-    @user = User.find_by_email(search_params[:email])
+    @user = User.find_for_database_authentication(search_params)
     if @user
       if @user.confirmed_at.nil?
         @user.send_confirmation_instructions
@@ -51,7 +51,7 @@ class VerificationController < ApplicationController
   end
 
   def search_params
-    params.require(:user).permit(:email)
+    params.require(:user).permit(:login)
   end
 
   def already_verified_alert

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -57,4 +57,9 @@ module ApplicationHelper
       "signed-in"
     end
   end
+
+  def current_election
+    election = Election.active.last
+    render partial: "application/election", locals: { election: election } unless election.nil?
+  end
 end

--- a/app/models/concerns/verificable.rb
+++ b/app/models/concerns/verificable.rb
@@ -168,4 +168,8 @@ module Verificable
   def verify_online! user
     update(verified_online_at: Time.zone.now, verified_online_by: user)
   end
+
+  def unverify!
+    update(verified_online_at: nil, verified_at: nil, verified_by: nil, verified_online_by: nil)
+  end
 end

--- a/app/models/election.rb
+++ b/app/models/election.rb
@@ -9,6 +9,7 @@ class Election < ApplicationRecord
   has_many :votes
   has_many :election_locations, dependent: :destroy
 
+  default_scope { order(created_at: :desc) }
   scope :active, -> { where("? BETWEEN starts_at AND ends_at", Time.zone.now).order(priority: :asc) }
   scope :upcoming_finished, -> { where("ends_at > ? AND starts_at < ?", 2.days.ago, 12.hours.from_now).order(priority: :asc) }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :trackable, :lockable
 
   before_save :before_save
+  before_save :updated_location, if: :location_changed?
 
   acts_as_paranoid
   has_paper_trail
@@ -582,5 +583,15 @@ class User < ApplicationRecord
 
   def sms_check_token
     Digest::SHA1.digest("#{sms_check_at}#{id}#{Rails.application.secrets.users['sms_secret_key']}")[0..3].codepoints.map { |c| "%02X" % c }.join if sms_check_at
+  end
+
+  private
+
+  def updated_location
+    self.verified_by, self.verified_at, self.verified_online_by, self.verified_online_at = nil
+  end
+
+  def location_changed?
+    address_changed? || town_changed? || province_changed? || postal_code_changed?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -113,6 +113,7 @@ class User < ApplicationRecord
   attr_accessor :sms_user_token_given
   attr_accessor :login
 
+  default_scope { order(created_at: :desc) }
   scope :wants_newsletter, -> { where(wants_newsletter: true) }
   scope :created, -> { not_banned }
   scope :deleted, -> { only_deleted }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :trackable, :lockable
 
   before_save :before_save
-  before_save :updated_location, if: :location_changed?
+  before_update :updated_location, if: :location_changed?
 
   acts_as_paranoid
   has_paper_trail

--- a/app/views/application/_documents_form.html.erb
+++ b/app/views/application/_documents_form.html.erb
@@ -11,6 +11,7 @@
             <li><%= t('sms_validator.documents.local_id') %></li>
             <li><%= t('sms_validator.documents.foreign_id') %></li>
             <li><%= t('sms_validator.documents.foreign_cera_id') %></li>
+            <li><%= raw t('sms_validator.phone.help_html') %></li>
           </ul>
         </div>
       <% else %>

--- a/app/views/application/_election.html.erb
+++ b/app/views/application/_election.html.erb
@@ -1,0 +1,6 @@
+<div class="box-info login-box election-box">
+  <h2><%= t("voting.election_one") %></h2>
+  <p class="poll-q"><%= election.title %></p>
+  <p class="date"><%= l election.starts_at, format: :date %> - <%= l election.ends_at, format: :date %></p>
+
+</div>

--- a/app/views/devise/registrations/_form.html.erb
+++ b/app/views/devise/registrations/_form.html.erb
@@ -103,6 +103,7 @@
 
   <fieldset>
     <legend><span><%= t('domicilio') %></span></legend>
+    <p><%= t('registration.verify_on_update') %></p>
 
     <div class="inputlabel-box">
       <%= label :user, :catalonia_resident, class: "control-label" do %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -17,6 +17,8 @@
         </div>
       </div>
 
+      <%= current_election %>
+
       <div class="box-info login-box">
         <h2><%= t('devise.links.sign_in') %></h2>
 

--- a/app/views/verification/step1.html.erb
+++ b/app/views/verification/step1.html.erb
@@ -18,7 +18,7 @@
 
             <div class="inputlabel-box">
               <div class="input-box">
-                <%= f.input :email, as: :email, label: t('verification.email') %>
+                <%= f.input :login, as: :string, label: t('devise.links.email'), required: false %>
               </div>
             </div>
 

--- a/app/views/verification/step2.html.erb
+++ b/app/views/verification/step2.html.erb
@@ -16,6 +16,9 @@
             <b><%= t('verification.full_name') %></b>: <%= @user.full_name %>
           </li>
           <li>
+            <b><%= t('verification.email') %></b>: <%= @user.email %>
+          </li>
+          <li>
             <b><%= t('verification.document_type') %></b>: <%= @user.document_type_name %> - <%= @user.document_vatid %>
           </li>
           <li>

--- a/config/locales/app.ca.yml
+++ b/config/locales/app.ca.yml
@@ -401,6 +401,7 @@ Conforme a allò convingut a l'article 16.3 de la Llei Orgànica de Protecció d
     country: País
     province: Província
     town: Municipi
+    verify_on_update: Quan editeu les dades de domicili, s'ha de realitzar novament el procés de verificació.
     inscription_policy: Condicions d'inscripció
     legends:
       inscription_html: "Inscriure's a En Comú et dóna dret a participar en totes les consultes i processos participatius que s'endeguin en aquesta aplicació. No representa cap mena d'obligació econòmica encara que pots col·laborar en aquest sentit si ho desitges. En acceptar-hi, rebràs tots els nostres butlletins informatius.<br><br> EN COMÚ amb personalitat jurídica pròpia, d'acord amb la Llei Orgànica 6/2002, de 27 de juny, de Partits Polítics, i inscrita en el Registre de Partits Polítics amb data de l'1 d'abril del 2015, Full 113, Volum IX. Domicili social: C. Or, 44 3º-2ª (CP 08012 BARCELONA). Telèfon: 935.321.796. "

--- a/config/locales/app.ca.yml
+++ b/config/locales/app.ca.yml
@@ -389,7 +389,7 @@ Conforme a allò convingut a l'article 16.3 de la Llei Orgànica de Protecció d
       token: Codi SMS
       button: "Comprova"
       information_html: "Has d'ingressar un telèfon mòbil vàlid per al país on et trobes, sense prefix internacional, només amb números (sense espais ni guions). Segons el formulari que has emplenat et trobes a <b>%{country}</b> (prefix internacional +%{prefix})."
-      help_html: "Actualment estem tenint alguns problemes amb els enviaments a mòbils de fora d'Espanya. Si és el teu cas, si us plau escriu a <a href='mailto:contacte@catalunyaencomu.cat'>contacte@catalunyaencomu.cat</a>"
+      help_html: "Si tens qualsevol problema escriu a <a href='mailto:contacte@catalunyaencomu.cat'>contacte@catalunyaencomu.cat</a>"
   static:
     privacy: Política de privacitat
     legal: Avís legal

--- a/config/locales/app.ca.yml
+++ b/config/locales/app.ca.yml
@@ -28,7 +28,7 @@ ca:
       apologize: >-
         Si no ha sigut el teu cas, et demanem disculpes per aquest correu.
   home:
-    signup_title: Inscriu-te per poder votar
+    signup_title: Inscriu-te per poder participar
   election:
     close_message: "Ha arribat la data límit per votar. La votació està tancada."
   errors:
@@ -430,7 +430,7 @@ Conforme a allò convingut a l'article 16.3 de la Llei Orgànica de Protecció d
           Per poder votar en les properes votacions t'has d'enregistrar
           omplint aquest formulari. T'arribarà un correu per validar-te. Si no
           reps el correu posa't en contacte amb nosaltres
-          <a href='http://catalunyaencomu.cat/contacte'>aquí</a>.
+          <a href='mailto:contacte@catalunyaencomu.cat'>aquí</a>.
         </p>
         "
   unauthorized:
@@ -776,7 +776,7 @@ Amb tres passos molt senzills:
     full_name: Nom complet
     document_type: Tipus i número de document
     email: Correu electrònic
-    result:  "Aquestes són les dades associades a l'email introduït:"
+    result:  "Aquestes són les dades associades:"
     check: "Comprova que:"
     other: Verifica un altre usuari/ària.
     admin: Gestor de verificacions presencials

--- a/config/locales/app.es.yml
+++ b/config/locales/app.es.yml
@@ -33,7 +33,7 @@ es:
       apologize: >-
         Si no ha sido tu caso, te pedimos disculpas por este correo.
   home:
-    signup_title: Inscríbete para poder votar
+    signup_title: Inscríbete para poder participar
   election:
     close_message: "Ha llegado la fecha límite para votar. La votación está cerrada."
   errors:
@@ -772,7 +772,7 @@ De conformidad con lo dispuesto en el artículo 16.3 de la Ley Orgánica de Prot
           Para votar en las próximas votaciones te tienes que registrar
           rellenando este formulario. Te llegará un correo para validarte. Si
           no recibes el correo ponte en contacto con nosotros
-          <a href='http://catalunyaencomu.cat/ca/contacte'>aquí</a>.
+          <a href='mailto:contacte@catalunyaencomu.cat'>aquí</a>.
         </p>
         "
   unauthorized:
@@ -1119,7 +1119,7 @@ De conformidad con lo dispuesto en el artículo 16.3 de la Ley Orgánica de Prot
     born_at: Fecha de nacimiento
     document_type: Tipo y número de documento
     email: Correo electrónico
-    result: "Estos son los datos asociados al email introducido:"
+    result: "Estos son los datos asociados:"
     check: "Comprova que:"
     admin: Gestor de verificaciones presenciales
     alerts:

--- a/config/locales/app.es.yml
+++ b/config/locales/app.es.yml
@@ -730,7 +730,7 @@ De conformidad con lo dispuesto en el artículo 16.3 de la Ley Orgánica de Prot
       token: Código SMS
       button: "Comprobar"
       information_html: "Debes ingresar un teléfono móvil válido para el país en el que te encuentras, sin prefijo internacional, sólo con números (sin espacios ni guiones). Según el formulario que has rellenado te encuentras en <b>%{country}</b> (prefijo internacional +%{prefix})."
-      help_html: "Actualmente estamos teniendo algunos problemas con los envíos a móviles de fuera de España. Si es tu caso, por favor escribe a <a href='mailto:contacte@catalunyaencomu.cat'>contacte@catalunyaencomu.cat</a>"
+      help_html: "Si tienes algún problema por favor escribe a <a href='mailto:contacte@catalunyaencomu.cat'>contacte@catalunyaencomu.cat</a>"
   static:
     privacy: Política de privacidad
     legal: Aviso legal

--- a/config/locales/app.es.yml
+++ b/config/locales/app.es.yml
@@ -742,6 +742,7 @@ De conformidad con lo dispuesto en el artículo 16.3 de la Ley Orgánica de Prot
     country: "País"
     province: "Provincia"
     town: "Municipio"
+    verify_on_update: Al modificar los datos de domicilio, se debe realizar nuevamente el proceso de verificación.
     inscription_policy: Condiciones de inscripción
     legends:
       inscription_html: "Inscribirse en En Comú te da derecho a participar en todas las consultas y procesos participativos que se lancen en esta aplicación. No supone ninguna obligación económica, aunque puedes colaborar en este sentido si lo deseas. Aceptando, recibirás nuestros newsletters informativos.<br><br> EN COMÚ con personalidad jurídica propia, de acuerdo con la Ley Orgánica 6/2002, de 27 de junio, de Partidos Políticos, e inscrita en el Registro de Partidos Políticos con fecha 1 de abril de 2015, Folio 113, Tomo IX. Domicilio social: C. Or, 44 3º-2ª (CP 08012 BARCELONA). Telèfon: 935.321.796. "

--- a/config/locales/devise.ca.yml
+++ b/config/locales/devise.ca.yml
@@ -2,7 +2,7 @@ ca:
   devise:
     confirmations:
       confirmed: "La teva adreça de correu electrònic ha estat confirmada. Pots iniciar sessió."
-      send_instructions: "Rebràs un correu electrònic en uns minuts amb instruccions sobre com restablir la teva contrasenya."
+      send_instructions: "Rebràs un correu electrònic en uns minuts amb instruccions sobre com restablir la teva contrasenya. Si tens qualsevol problema contacta amb contacte@catalunyaencomu.cat"
       send_paranoid_instructions: "Si el teu correu electrònic existeix a la nostra base de dades, rebràs un correu electrònic d'aquí a uns minuts amb instruccions sobre com reiniciar la teva contrasenya."
     failure:
       already_authenticated: "Ja estàs identificat."

--- a/config/locales/devise.es.yml
+++ b/config/locales/devise.es.yml
@@ -2,7 +2,7 @@ es:
   devise:
     confirmations:
       confirmed: "Tu dirección de correo electrónico ha sido confirmada. Puedes iniciar sesión."
-      send_instructions: "Recibirás un correo electrónico en unos minutos con instrucciones sobre cómo restablecer tu contraseña."
+      send_instructions: "Recibirás un correo electrónico en unos minutos con instrucciones sobre cómo restablecer tu contraseña. Si tienes algún problema contacta a contacte@catalunyaencomu.cat"
       send_paranoid_instructions: "Si tu correo electrónico existe en nuestra base de datos recibirás un correo electrónico en unos minutos con instrucciones sobre cómo reiniciar tu contraseña."
     failure:
       already_authenticated: "Ya estás identificado."

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -86,4 +86,10 @@ class ApplicationHelperTest < ActionView::TestCase
     expected = "logged-out"
     assert_equal expected, result
   end
+
+  test "should current_election work" do
+    create(:election, :opened)
+    result = current_election
+    assert_not_nil result
+  end
 end

--- a/test/integration/home_test.rb
+++ b/test/integration/home_test.rb
@@ -9,6 +9,12 @@ class HomeTest < ActionDispatch::IntegrationTest
     assert_title "Iniciar sesión"
   end
 
+  test "show current election info" do
+    create(:election, :opened)
+    visit root_path
+    assert_text "Hay una votación en curso."
+  end
+
   test "does not redirect" do
     I18n.with_locale(:es) do
       visit root_path

--- a/test/integration/verification_presencial_test.rb
+++ b/test/integration/verification_presencial_test.rb
@@ -74,7 +74,7 @@ class VerificationPresencialTest < JsFeatureTest
     verificator = create(:user, :verifying_presentially)
     login(verificator)
     visit verification_step1_path
-    fill_in(:user_email, with: user.email)
+    fill_in(:user_login, with: user.email)
     click_button('Siguiente')
     assert_content I18n.t('verification.result')
     click_link('Verificar')
@@ -93,7 +93,7 @@ class VerificationPresencialTest < JsFeatureTest
     verificator = create(:user, :verifying_presentially)
     login(verificator)
     visit verification_step1_path
-    fill_in(:user_email, with: user.email)
+    fill_in(:user_login, with: user.email)
     click_button('Siguiente')
     assert_content I18n.t('verification.result')
     click_link('No verificar')
@@ -111,7 +111,7 @@ class VerificationPresencialTest < JsFeatureTest
     verificator = create(:user, :verifying_presentially)
     login(verificator)
     visit verification_step1_path
-    fill_in(:user_email, with: unconfirmed_user.email)
+    fill_in(:user_login, with: unconfirmed_user.email)
 
     assert_difference -> { ActionMailer::Base.deliveries.count }, 1 do
       click_button('Siguiente')
@@ -126,5 +126,18 @@ class VerificationPresencialTest < JsFeatureTest
     refute \
       unconfirmed_user.reload.is_verified_presentially?,
       "User shouldn't be verified presentially but it is"
+  end
+
+  test "can verify by document number" do
+    user = create(:user)
+    verificator = create(:user, :verifying_presentially)
+    login(verificator)
+    visit verification_step1_path
+    fill_in(:user_login, with: user.document_vatid)
+    click_button('Siguiente')
+    assert_content I18n.t('verification.result')
+    assert_content user.email
+    click_link('Verificar')
+    assert_content I18n.t('verification.alerts.ok.title')
   end
 end


### PR DESCRIPTION
Requested changes in ticket 1407:

## Index
- [ ] Welcome text
- [x] Registration text
- [x] Display current election

## Registration
- [x] Registration form contact
- [ ] Captcha alternative (optional)
- [x] Resend confirmation email

## Verifications
- [x] Force verification when user modify address
- [ ] Display message when no offline verification
- [x] Display contact email in new verification

## Offline verifications
- [ ] Map slot bug
- [ ] Display map ancho

## SMS
- [x] Change issue text

## Verification
- [x] Allow search by document number and email

## Admin
- [x] Sort by creation date elections and users
- [x] Remove 0034 from phone in download page